### PR TITLE
Add .lib files in windows

### DIFF
--- a/includes/array.h
+++ b/includes/array.h
@@ -20,7 +20,7 @@ SHARED_EXPORT typedef OWObject_t OWO_Array_t;
 /**
  * A structure to hold all object's virtual methods
  */
-SHARED_EXPORT struct _OWArray_Methods {
+struct _OWArray_Methods {
   int(*resize)(OWO_Array_t* this, size_t slots);
 };
 

--- a/includes/array.h
+++ b/includes/array.h
@@ -15,12 +15,12 @@
  *
  * A type for human reference
  */
-typedef OWObject_t OWO_Array_t;
+SHARED_EXPORT typedef OWObject_t OWO_Array_t;
 
 /**
  * A structure to hold all object's virtual methods
  */
-struct _OWArray_Methods {
+SHARED_EXPORT struct _OWArray_Methods {
   int(*resize)(OWO_Array_t* this, size_t slots);
 };
 
@@ -31,7 +31,7 @@ struct _OWArray_Methods {
  *
  * @extends OWObject_t
  */
-typedef struct {
+SHARED_EXPORT typedef struct {
   /**
    * @brief Variadic array for the object's stored data
    *
@@ -106,7 +106,7 @@ typedef struct {
  *
  * @memberof OWArray_t
  */
-OWO_Array_t* OWArray_Construct(size_t slot_size, size_t slots);
+SHARED_EXPORT OWO_Array_t* OWArray_Construct(size_t slot_size, size_t slots);
 
 /**
  * @brief Access array's methods
@@ -140,7 +140,7 @@ OWO_Array_t* OWArray_Construct(size_t slot_size, size_t slots);
  * @brief The default implementation for OWArray_Resize
  * @memberof OWArray_t
  */
-int _OWArray_Resize(OWO_Array_t* this, size_t slots);
+SHARED_EXPORT int _OWArray_Resize(OWO_Array_t* this, size_t slots);
 
 /**
  * @copydoc OWIsEqualCallback_t
@@ -152,7 +152,7 @@ int _OWArray_Resize(OWO_Array_t* this, size_t slots);
  * @brief The default implementation for OWArray_IsEqual
  * @memberof OWArray_t
  */
-bool _OWArray_IsEqual(OWO_Array_t* this, OWObject_t* other);
+SHARED_EXPORT bool _OWArray_IsEqual(OWO_Array_t* this, OWObject_t* other);
 
 /**
  * @brief Access a slot in the array

--- a/includes/ctypes.h
+++ b/includes/ctypes.h
@@ -22,7 +22,7 @@
  *
  * @extends OWObject_t
  */
-typedef struct {
+SHARED_EXPORT typedef struct {
   void* value;
   size_t size;
 } OWCType_t;
@@ -32,7 +32,7 @@ typedef struct {
  *
  * A type for human reference
  */
-typedef OWObject_t OWO_CType_t;
+SHARED_EXPORT typedef OWObject_t OWO_CType_t;
 
 #define OWCType_UnWrap(c_type, this) (*(c_type*)((OWCType_t*)OWObject_FindObjectInClass(this, OWID_CTYPE))->value)
 
@@ -45,7 +45,7 @@ typedef OWObject_t OWO_CType_t;
  *
  * @extends OWCType_t
  */
-typedef OWObject_t OWO_Integer_t;
+SHARED_EXPORT typedef OWObject_t OWO_Integer_t;
 
 /**
  * @brief Construct an integer
@@ -57,7 +57,7 @@ typedef OWObject_t OWO_Integer_t;
  * @returns A pointer to the object instance that was created or `NULL` on failure.
  * @memberof OWInteger_t
  */
-OWO_Integer_t* OWInteger_Construct(int object);
+SHARED_EXPORT OWO_Integer_t* OWInteger_Construct(int object);
 
 /**
  * @brief Extract an OWInteger
@@ -80,7 +80,7 @@ OWO_Integer_t* OWInteger_Construct(int object);
  *
  * @extends OWCType_t
  */
-typedef OWObject_t OWO_UnsignedInteger8_t;
+SHARED_EXPORT typedef OWObject_t OWO_UnsignedInteger8_t;
 
 /**
  * @brief Construct an unsigned 8-bit integer
@@ -92,7 +92,7 @@ typedef OWObject_t OWO_UnsignedInteger8_t;
  * @returns A pointer to the object instance that was created or `NULL` on failure.
  * @memberof OWUnsignedInteger8_t
  */
-OWO_UnsignedInteger8_t* OWUnsignedInteger8_Construct(uint8_t object);
+SHARED_EXPORT OWO_UnsignedInteger8_t* OWUnsignedInteger8_Construct(uint8_t object);
 
 /**
  * @brief Extract an OWUnsignedInteger8_t
@@ -115,7 +115,7 @@ OWO_UnsignedInteger8_t* OWUnsignedInteger8_Construct(uint8_t object);
  *
  * @extends OWCType_t
  */
-typedef OWObject_t OWO_Character_t;
+SHARED_EXPORT typedef OWObject_t OWO_Character_t;
 
 /**
  * @brief Construct a character
@@ -127,7 +127,7 @@ typedef OWObject_t OWO_Character_t;
  * @returns A pointer to the object instance that was created or `NULL` on failure.
  * @memberof OWCharacter_t
  */
-OWO_Character_t* OWCharacter_Construct(char object);
+SHARED_EXPORT OWO_Character_t* OWCharacter_Construct(char object);
 
 /**
  * @brief Extract an OWCharacter
@@ -150,7 +150,7 @@ OWO_Character_t* OWCharacter_Construct(char object);
  *
  * @extends OWCType_t
  */
-typedef OWObject_t OWO_Boolean_t;
+SHARED_EXPORT typedef OWObject_t OWO_Boolean_t;
 
 /**
  * @brief Construct a boolean
@@ -162,7 +162,7 @@ typedef OWObject_t OWO_Boolean_t;
  * @returns A pointer to the object instance that was created or `NULL` on failure.
  * @memberof OWBoolean_t
  */
-OWO_Boolean_t* OWBoolean_Construct(bool object);
+SHARED_EXPORT OWO_Boolean_t* OWBoolean_Construct(bool object);
 
 /**
  * @brief Extract an OWBoolean

--- a/includes/map.h
+++ b/includes/map.h
@@ -17,10 +17,10 @@
  *
  * A type for human reference
  */
-typedef OWObject_t OWO_Map_t;
+SHARED_EXPORT typedef OWObject_t OWO_Map_t;
 
 
-struct _OWMap_Methods {
+SHARED_EXPORT struct _OWMap_Methods {
   int(*set)(OWO_Map_t* this, OWObject_t* key, OWObject_t* item);
   int(*unset)(OWO_Map_t* this, OWObject_t* key);
   size_t(*find_entry)(OWO_Map_t* this, OWObject_t* key);
@@ -36,7 +36,7 @@ struct _OWMap_Methods {
  * @note Can only hold references to OWObject_t objects and unreferences
  *       when they are removed from the map
  */
-typedef struct {
+SHARED_EXPORT typedef struct {
   /**
    * @brief Key vector
    *
@@ -90,7 +90,7 @@ typedef struct {
  *
  * @memberof OWMap_t
  */
-OWO_Map_t* OWMap_Construct(size_t slot_steps);
+SHARED_EXPORT OWO_Map_t* OWMap_Construct(size_t slot_steps);
 
 /**
  * @brief Get the methods struct of the OWMap_t object
@@ -120,7 +120,7 @@ OWO_Map_t* OWMap_Construct(size_t slot_steps);
  * @brief Default implementation of OWMap_Set
  * @memberof OWMap_t
  */
-int _OWMap_Set(OWO_Map_t* this, OWObject_t* key, OWObject_t* item);
+SHARED_EXPORT int _OWMap_Set(OWO_Map_t* this, OWObject_t* key, OWObject_t* item);
 
 /**
  * @brief Unset a key in the map
@@ -144,7 +144,7 @@ int _OWMap_Set(OWO_Map_t* this, OWObject_t* key, OWObject_t* item);
  * @brief Default implementation of OWMap_UnSet
  * @memberof OWMap_t
  */
-int _OWMap_UnSet(OWO_Map_t* this, OWObject_t* key);
+SHARED_EXPORT int _OWMap_UnSet(OWO_Map_t* this, OWObject_t* key);
 
 
 /**
@@ -164,7 +164,7 @@ int _OWMap_UnSet(OWO_Map_t* this, OWObject_t* key);
  * @brief Default implementation of OWMap_FindEntry
  * @memberof OWMap_t
  */
-size_t _OWMap_FindEntry(OWO_Map_t* this, OWObject_t* key);
+SHARED_EXPORT size_t _OWMap_FindEntry(OWO_Map_t* this, OWObject_t* key);
 
 /**
  * @brief Get the value of a key
@@ -186,7 +186,7 @@ size_t _OWMap_FindEntry(OWO_Map_t* this, OWObject_t* key);
  * @brief Default implementation of OWMap_Get
  * @memberof OWMap_t
  */
-OWObject_t* _OWMap_Get(OWO_Map_t* this, OWObject_t* key);
+SHARED_EXPORT OWObject_t* _OWMap_Get(OWO_Map_t* this, OWObject_t* key);
 
 /**
  * @brief Get the vector of keys of the object
@@ -213,7 +213,7 @@ OWObject_t* _OWMap_Get(OWO_Map_t* this, OWObject_t* key);
  * @brief Default implementation of OWMap_IsEqual
  * @memberof OWMap_t
  */
-bool _OWMap_IsEqual(OWO_Map_t* this, OWObject_t* other);
+SHARED_EXPORT bool _OWMap_IsEqual(OWO_Map_t* this, OWObject_t* other);
 
 /**
  * @brief Get the size of the map

--- a/includes/map.h
+++ b/includes/map.h
@@ -20,7 +20,7 @@
 SHARED_EXPORT typedef OWObject_t OWO_Map_t;
 
 
-SHARED_EXPORT struct _OWMap_Methods {
+struct _OWMap_Methods {
   int(*set)(OWO_Map_t* this, OWObject_t* key, OWObject_t* item);
   int(*unset)(OWO_Map_t* this, OWObject_t* key);
   size_t(*find_entry)(OWO_Map_t* this, OWObject_t* key);

--- a/includes/object.h
+++ b/includes/object.h
@@ -16,6 +16,12 @@
 #define _Atomic
 #endif
 
+#ifdef _WIN32
+  #define SHARED_EXPORT __declspec(dllexport)
+#else
+  #define SHARED_EXPORT
+#endif
+
 /**
  * @brief Register a new OWID for a class
  *
@@ -58,7 +64,7 @@
  */
 #define OWContainer_Type(container, ...) container
 
-struct OWObject_struct;
+SHARED_EXPORT struct OWObject_struct;
 
 /**
  * @brief The object's destructor function type
@@ -67,7 +73,7 @@ struct OWObject_struct;
  *
  * The destructor needs to make sure everything inside the object is deallocated.
  */
-typedef void(OWDestroyCallback_t)(struct OWObject_struct* this);
+SHARED_EXPORT typedef void(OWDestroyCallback_t)(struct OWObject_struct* this);
 
 /**
  * @brief The object's IsEqual function type
@@ -79,9 +85,9 @@ typedef void(OWDestroyCallback_t)(struct OWObject_struct* this);
  *
  * @returns The equality check results
  */
-typedef bool(OWIsEqualCallback_t)(struct OWObject_struct* this, struct OWObject_struct* other);
+SHARED_EXPORT typedef bool(OWIsEqualCallback_t)(struct OWObject_struct* this, struct OWObject_struct* other);
 
-struct OWObject_struct {
+SHARED_EXPORT struct OWObject_struct {
 
   /**
    * @brief Reference to the super/parent of the current object
@@ -146,7 +152,7 @@ struct OWObject_struct {
  * Container allowing variadic data to be stored in it.
  * Capable of holding a reference to the parent of the current class/object.
  */
-typedef struct OWObject_struct OWObject_t;;
+SHARED_EXPORT typedef struct OWObject_struct OWObject_t;;
 
 /**
  * @brief Easier object constructor
@@ -188,7 +194,7 @@ typedef struct OWObject_struct OWObject_t;;
  * @returns A pointer to the constructed `OWObject_t` instance or `NULL` on failure.
  * @memberof OWObject_t
  */
-OWObject_t* _OWObject_Construct(size_t size, OWID type, OWObject_t* super, OWDestroyCallback_t* destroy_callback, OWIsEqualCallback_t* is_equal_callback);
+SHARED_EXPORT OWObject_t* _OWObject_Construct(size_t size, OWID type, OWObject_t* super, OWDestroyCallback_t* destroy_callback, OWIsEqualCallback_t* is_equal_callback);
 
 /**
  * @brief Find an object in inheritance chain
@@ -201,7 +207,7 @@ OWObject_t* _OWObject_Construct(size_t size, OWID type, OWObject_t* super, OWDes
  * @returns A pointer to the discovered `OWObject_t` instance or `NULL` on failure.
  * @memberof OWObject_t
  */
-OWObject_t* OWObject_FindTypeInClass(OWObject_t* this, OWID type);
+SHARED_EXPORT OWObject_t* OWObject_FindTypeInClass(OWObject_t* this, OWID type);
 
 /**
  * @brief Find an object's data in the inheritance chain
@@ -214,7 +220,7 @@ OWObject_t* OWObject_FindTypeInClass(OWObject_t* this, OWID type);
  * @returns A pointer to the data of the discovered `OWObject_t` instance (which is of unknown/variadic type) or `NULL` on failure.
  * @memberof OWObject_t
  */
-void* OWObject_FindObjectInClass(OWObject_t* this, OWID type);
+SHARED_EXPORT void* OWObject_FindObjectInClass(OWObject_t* this, OWID type);
 
 /**
  * @brief Get a new reference to an object.
@@ -226,7 +232,7 @@ void* OWObject_FindObjectInClass(OWObject_t* this, OWID type);
  * @returns A pointer pointing to the same address as `this`.
  * @memberof OWObject_t
  */
-OWObject_t* OWObject_Ref(OWObject_t* this);
+SHARED_EXPORT OWObject_t* OWObject_Ref(OWObject_t* this);
 
 /**
  * @brief Destroy a reference to an object.
@@ -237,7 +243,7 @@ OWObject_t* OWObject_Ref(OWObject_t* this);
  *
  * @memberof OWObject_t
  */
-void OWObject_UnRef(OWObject_t* this);
+SHARED_EXPORT void OWObject_UnRef(OWObject_t* this);
 
 /**
  * @brief Get the number of references to the object.
@@ -264,7 +270,7 @@ void OWObject_UnRef(OWObject_t* this);
  * @returns The result of the equality check
  * @memberof OWObject_t
  */
-bool OWObject_IsEqual(OWObject_t* this, OWObject_t* other);
+SHARED_EXPORT bool OWObject_IsEqual(OWObject_t* this, OWObject_t* other);
 
 /**
  * @brief Destroy an object
@@ -276,7 +282,7 @@ bool OWObject_IsEqual(OWObject_t* this, OWObject_t* other);
  *
  * @memberof OWObject_t
  */
-void OWObject_Destroy(OWObject_t* this);
+SHARED_EXPORT void OWObject_Destroy(OWObject_t* this);
 
 
 

--- a/includes/object.h
+++ b/includes/object.h
@@ -64,7 +64,7 @@
  */
 #define OWContainer_Type(container, ...) container
 
-SHARED_EXPORT struct OWObject_struct;
+struct OWObject_struct;
 
 /**
  * @brief The object's destructor function type
@@ -87,7 +87,7 @@ SHARED_EXPORT typedef void(OWDestroyCallback_t)(struct OWObject_struct* this);
  */
 SHARED_EXPORT typedef bool(OWIsEqualCallback_t)(struct OWObject_struct* this, struct OWObject_struct* other);
 
-SHARED_EXPORT struct OWObject_struct {
+struct OWObject_struct {
 
   /**
    * @brief Reference to the super/parent of the current object

--- a/includes/object_identifiers.h
+++ b/includes/object_identifiers.h
@@ -1,6 +1,14 @@
 #ifndef OW_OBJECT_IDENTIFIERS_H
 #define OW_OBJECT_IDENTIFIERS_H
 
+#ifndef SHARED_EXPORT
+  #ifdef _WIN32
+    #define SHARED_EXPORT __declspec(dllexport)
+  #else
+    #define SHARED_EXPORT
+  #endif
+#endif
+
 /**
  * @file object_identifiers.h
  * @brief Object Wrapper Identifier
@@ -15,8 +23,8 @@
  *
  * All values for this type should have the `OWID_` prefix.
  */
-typedef int OWID;
-enum {
+SHARED_EXPORT typedef int OWID;
+SHARED_EXPORT enum {
   OWID_UNDEFINED = 0,
   OWID_VECTOR = 1,
   OWID_STRING = 2,

--- a/includes/object_identifiers.h
+++ b/includes/object_identifiers.h
@@ -24,7 +24,7 @@
  * All values for this type should have the `OWID_` prefix.
  */
 SHARED_EXPORT typedef int OWID;
-SHARED_EXPORT enum {
+enum {
   OWID_UNDEFINED = 0,
   OWID_VECTOR = 1,
   OWID_STRING = 2,

--- a/includes/ow_string.h
+++ b/includes/ow_string.h
@@ -18,9 +18,9 @@
  *
  * Create a type for human reference
  */
-typedef OWObject_t OWO_String_t;
+SHARED_EXPORT typedef OWObject_t OWO_String_t;
 
-struct _OWString_Methods {
+SHARED_EXPORT struct _OWString_Methods {
   int(*set)(OWO_String_t* this, const char* content, size_t content_size);
   int(*append)(OWO_String_t* this, const char* content, size_t content_size);
   int(*compare)(OWO_String_t* this, const char* content, size_t content_size);
@@ -35,7 +35,7 @@ struct _OWString_Methods {
  *
  * @extends OWArray_t
  */
-typedef struct {
+SHARED_EXPORT typedef struct {
   size_t size; // This does NOT count the NULL-byte
   struct _OWString_Methods methods;
 } OWString_t;
@@ -58,7 +58,7 @@ typedef struct {
  * @returns A pointer to the object instance that was created or `NULL` on failure.
  * @memberof OWString_t
  */
-OWO_String_t* OWString_Construct(const char* content, size_t content_size);
+SHARED_EXPORT OWO_String_t* OWString_Construct(const char* content, size_t content_size);
 
 /**
  * @brief Construct an empty string
@@ -112,7 +112,7 @@ OWO_String_t* OWString_Construct(const char* content, size_t content_size);
  * @brief Default implementation of OWString_Set
  * @memberof OWString_t
  */
-int _OWString_Set(OWO_String_t* this, const char* content, size_t content_size);
+SHARED_EXPORT int _OWString_Set(OWO_String_t* this, const char* content, size_t content_size);
 
 /**
  * @brief A simple way to set a string's contents
@@ -159,7 +159,7 @@ int _OWString_Set(OWO_String_t* this, const char* content, size_t content_size);
  * @brief Default implementation of OWString_Append
  * @memberof OWString_t
  */
-int _OWString_Append(OWO_String_t* this, const char* content, size_t content_size);
+SHARED_EXPORT int _OWString_Append(OWO_String_t* this, const char* content, size_t content_size);
 
 /**
  * @brief A simple way to add content to an OWString
@@ -216,7 +216,7 @@ int _OWString_Append(OWO_String_t* this, const char* content, size_t content_siz
  * @brief Default implementation of OWString_Compare
  * @memberof OWString_t
  */
-int _OWString_Compare(OWO_String_t* this, const char* other, size_t other_size);
+SHARED_EXPORT int _OWString_Compare(OWO_String_t* this, const char* other, size_t other_size);
 
 /**
  * @brief A simple way to use compare an OWString to a c-string
@@ -260,7 +260,7 @@ int _OWString_Compare(OWO_String_t* this, const char* other, size_t other_size);
  * @brief Default implementation of OWString_IsEqual
  * @memberof OWString_t
  */
-bool _OWString_IsEqual(OWO_String_t* this, OWObject_t* other);
+SHARED_EXPORT bool _OWString_IsEqual(OWO_String_t* this, OWObject_t* other);
 
 /**
  * @brief Get a substring from an OWString's content
@@ -279,7 +279,7 @@ bool _OWString_IsEqual(OWO_String_t* this, OWObject_t* other);
  * @brief Default implementation of OWString_SubString
  * @memberof OWString_t
  */
-OWO_String_t* _OWString_SubString(OWO_String_t* this, size_t start, size_t size);
+SHARED_EXPORT OWO_String_t* _OWString_SubString(OWO_String_t* this, size_t start, size_t size);
 
 /**
  * @brief Find a substring in the OWString's content
@@ -298,7 +298,7 @@ OWO_String_t* _OWString_SubString(OWO_String_t* this, size_t start, size_t size)
  * @brief Default implementation of OWString_FindStr
  * @memberof OWString_t
  */
-size_t _OWString_FindStr(OWO_String_t* this, const char* sub, size_t sub_size);
+SHARED_EXPORT size_t _OWString_FindStr(OWO_String_t* this, const char* sub, size_t sub_size);
 
 /**
  * @brief Simple way to call @ref OWString_FindStr

--- a/includes/ow_string.h
+++ b/includes/ow_string.h
@@ -20,7 +20,7 @@
  */
 SHARED_EXPORT typedef OWObject_t OWO_String_t;
 
-SHARED_EXPORT struct _OWString_Methods {
+struct _OWString_Methods {
   int(*set)(OWO_String_t* this, const char* content, size_t content_size);
   int(*append)(OWO_String_t* this, const char* content, size_t content_size);
   int(*compare)(OWO_String_t* this, const char* content, size_t content_size);

--- a/includes/vector.h
+++ b/includes/vector.h
@@ -20,7 +20,7 @@
 SHARED_EXPORT typedef OWObject_t OWO_Vector_t;
 
 
-SHARED_EXPORT struct _OWVector_Methods {
+struct _OWVector_Methods {
   int(*insert)(OWO_Vector_t* this, size_t index, OWObject_t* item);
   OWObject_t*(*get)(OWO_Vector_t* this, size_t index);
   size_t(*finditem)(OWO_Vector_t* this, OWObject_t* item);

--- a/includes/vector.h
+++ b/includes/vector.h
@@ -17,10 +17,10 @@
  *
  * A type for human reference
  */
-typedef OWObject_t OWO_Vector_t;
+SHARED_EXPORT typedef OWObject_t OWO_Vector_t;
 
 
-struct _OWVector_Methods {
+SHARED_EXPORT struct _OWVector_Methods {
   int(*insert)(OWO_Vector_t* this, size_t index, OWObject_t* item);
   OWObject_t*(*get)(OWO_Vector_t* this, size_t index);
   size_t(*finditem)(OWO_Vector_t* this, OWObject_t* item);
@@ -40,7 +40,7 @@ struct _OWVector_Methods {
  *
  * @extends OWArray_t
  */
-typedef struct {
+SHARED_EXPORT typedef struct {
   /**
    * @brief The size of the vector
    *
@@ -104,7 +104,7 @@ typedef struct {
  *
  * @memberof OWVector_t
  */
-OWO_Vector_t* OWVector_Construct(size_t slot_steps);
+SHARED_EXPORT OWO_Vector_t* OWVector_Construct(size_t slot_steps);
 
 /**
  * @brief Resize the internal vector's buffer
@@ -142,7 +142,7 @@ OWO_Vector_t* OWVector_Construct(size_t slot_steps);
  * @brief Default implementation of OWVector_Insert
  * @memberof OWVector_t
  */
-int _OWVector_Insert(OWO_Vector_t* this, size_t index, OWObject_t* item);
+SHARED_EXPORT int _OWVector_Insert(OWO_Vector_t* this, size_t index, OWObject_t* item);
 
 /**
  * @brief Add an item to the end of the vector.
@@ -207,7 +207,7 @@ int _OWVector_Insert(OWO_Vector_t* this, size_t index, OWObject_t* item);
  * @brief Default implementation of OWVector_Get
  * @memberof OWVector_t
  */
-OWObject_t* _OWVector_Get(OWO_Vector_t* this, size_t index);
+SHARED_EXPORT OWObject_t* _OWVector_Get(OWO_Vector_t* this, size_t index);
 
 /**
  * @copydoc OWIsEqualCallback_t
@@ -219,7 +219,7 @@ OWObject_t* _OWVector_Get(OWO_Vector_t* this, size_t index);
  * @brief Default implementation of OWVector_IsEqual
  * @memberof OWVector_t
  */
-bool _OWVector_IsEqual(OWO_Vector_t* this, OWObject_t* other);
+SHARED_EXPORT bool _OWVector_IsEqual(OWO_Vector_t* this, OWObject_t* other);
 
 /**
  * @brief Find an item in the vector
@@ -237,7 +237,7 @@ bool _OWVector_IsEqual(OWO_Vector_t* this, OWObject_t* other);
  * @brief Default implementation of OWVector_FindItem
  * @memberof OWVector_t
  */
-size_t _OWVector_FindItem(OWO_Vector_t* this, OWObject_t* item);
+SHARED_EXPORT size_t _OWVector_FindItem(OWO_Vector_t* this, OWObject_t* item);
 
 /**
  * @brief Remove an object from the vector.
@@ -259,7 +259,7 @@ size_t _OWVector_FindItem(OWO_Vector_t* this, OWObject_t* item);
  * @brief Default implementation of OWVector_Remove
  * @memberof OWVector_t
  */
-int _OWVector_Remove(OWO_Vector_t* this, size_t index);
+SHARED_EXPORT int _OWVector_Remove(OWO_Vector_t* this, size_t index);
 
 /**
  * @brief Remove an object and get a reference to it.
@@ -282,7 +282,7 @@ int _OWVector_Remove(OWO_Vector_t* this, size_t index);
  * @brief Default implementation of OWVector_Pop
  * @memberof OWVector_t
  */
-OWObject_t* _OWVector_Pop(OWO_Vector_t* this, size_t index);
+SHARED_EXPORT OWObject_t* _OWVector_Pop(OWO_Vector_t* this, size_t index);
 
 /**
  * @brief Call @ref OWVector_Pop for the last item in the vector


### PR DESCRIPTION
Modified all header files to include __declspec(dllexport) when compiling on windows.

This __declspec(dllexport) is used through a preprocessor definition that disables it when compiling for Linux 


The preprocessor definition is defined in object.h and object_identifiers.h